### PR TITLE
Added Basic Import Flag Support

### DIFF
--- a/magma-go/cmd/magma/generatespec.go
+++ b/magma-go/cmd/magma/generatespec.go
@@ -2,13 +2,13 @@ package magma
 
 import (
 	"fmt"
-
 	"github.com/candostyavuz/magma/pkg/magma"
+
 	"github.com/spf13/cobra"
 )
 
 var genspecCmd = &cobra.Command{
-	Use:     "genspec [supported-apis-file] | Flags: [--chain-name] , [--chain-idx]",
+	Use:     "genspec [supported-apis-file] | Flags: [--chain-name] , [--chain-idx], [--imports]",
 	Aliases: []string{"gen"},
 	Short:   "Generates a valid spec file from a list of supported api calls",
 	Long: `Generates a valid spec file from a list of supported api calls.
@@ -16,6 +16,11 @@ var genspecCmd = &cobra.Command{
 	Args: cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		fmt.Println("File is: ", args[0])
+		imports, err := cmd.Flags().GetStringArray("import")
+		fmt.Println(imports)
+		if err != nil {
+			return err
+		}
 		chainName, err := cmd.Flags().GetString("chain-name")
 		if err != nil {
 			return err
@@ -24,7 +29,8 @@ var genspecCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
-		err = magma.GenerateSpec(args[0], chainName, chainIdx)
+
+		err = magma.GenerateSpec(args[0], chainName, chainIdx, imports)
 		return err
 	},
 }
@@ -32,5 +38,6 @@ var genspecCmd = &cobra.Command{
 func init() {
 	genspecCmd.Flags().String("chain-name", "", "Chain Name")
 	genspecCmd.Flags().String("chain-idx", "", "Chain Index")
+	genspecCmd.Flags().StringArray("import", nil, "Imports for this spec")
 	rootCmd.AddCommand(genspecCmd)
 }

--- a/magma-go/pkg/magma/magma.go
+++ b/magma-go/pkg/magma/magma.go
@@ -41,6 +41,7 @@ type APIData struct {
 	BlockParsing  BlockParsingData   `json:"block_parsing"`
 	ComputeUnits  string             `json:"compute_units"`
 	Enabled       bool               `json:"enabled"`
+	Imports       []string           `json:"imports"`
 	ApiInterfaces []ApiInterfaceData `json:"api_interfaces"`
 }
 
@@ -78,7 +79,7 @@ type APIMethod struct {
 }
 
 // LOGIC:
-func GenerateSpec(fileName string, chainNameFlag string, chainIdxFlag string) error {
+func GenerateSpec(fileName string, chainNameFlag string, chainIdxFlag string, imports []string) error {
 
 	// Check if fileName has ".yaml" extension, and add it if not
 	if !strings.HasSuffix(fileName, ".yaml") {
@@ -131,6 +132,7 @@ func GenerateSpec(fileName string, chainNameFlag string, chainIdxFlag string) er
 			},
 			ComputeUnits: "10",
 			Enabled:      true,
+			Imports:      imports,
 			ApiInterfaces: []ApiInterfaceData{
 				{
 					Category: CategoryData{


### PR DESCRIPTION
`genspec --import` is now supported where `--import` takes an array of Strings and passes them to the `GenerateSpec` as an argument to be added to the JSON field `imports`. 